### PR TITLE
Move React to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "url": "https://github.com/freiksenet/react-kinetic.git"
   },
   "dependencies": {
-    "kinetic": "5.0.6",
-    "react": "0.11.0"
+    "kinetic": "5.0.6"
+  },
+  "peerDependencies": {
+    "react": "^0.11.0"
   },
   "devDependencies": {
     "beefy": "1.1.0",


### PR DESCRIPTION
Currently the example code from README fails when React and react-kinetic are installed with npm:
"Uncaught Error: Invariant Violation: TestingComponent.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object."

This is because react-kinetic installs its own copy of React and thus the component descriptor returned by it is not recognized by React. Putting React to `peerDependencies` fixes this.
