### PR TITLE
Add keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "author": "Mikhail <freiksenet@gmail.com> Novikov",
   "description": "Using KineticJS library with React",
+  "keywords": [
+    "canvas",
+    "react",
+    "react-component"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Add keywords to help people find the package from npm.
- Add the package to http://react-components.com/ using `react-component` keyword.
